### PR TITLE
fix: mention regex for multiple mentions

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,7 +3,7 @@ import { Change, diffChars } from 'diff';
 import matchAll from 'string.prototype.matchall';
 import { MentionData, Part, Position, RegexMatchResult, Suggestion } from '../types';
 
-const mentionRegEx = /(?<original>@\[(?<name>.+)]\((?<id>([0-9]*))\))/gi;
+const mentionRegEx = /(?<original>@\[(?<name>([^@[]*))]\((?<id>([0-9]*))\))/gi;
 
 type CharactersDiffChange = Omit<Change, 'count'> & { count: number };
 


### PR DESCRIPTION
Excluded '@[' in regex 'name' group to correct matching few mentions with a word between them.

Fixes: #2