### PR TITLE
Added optional getMentionValue for allowing custom mention values

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -71,6 +71,9 @@ type MentionPartType = {
 
   // Required function when we have custom regex pattern
   parsePattern?: (regexParseResult: string[] & { index: number }) => MentionData,
+
+  // Custom transformation for getting mention value
+  getMentionValue?: (trigger: string, id: string, name: string) => string;
 };
 
 type PatternPartType = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -281,7 +281,7 @@ const generateValueWithAddedSuggestion = (
     // Create part with string before mention
     generatePlainTextPart(currentPart.text.substring(0, newMentionPartPosition.start)),
     generateMentionPart(mentionType, {
-      original: getMentionValue(mentionType.trigger, suggestion),
+      original: getMentionValue(mentionType, suggestion),
       trigger: mentionType.trigger,
       ...suggestion,
     }),
@@ -349,10 +349,18 @@ const generateRegexResultPart = (partType: PartType, result: RegexMatchResult, p
 /**
  * Method for generation mention value that accepts mention regex
  *
- * @param trigger
+ * @param mentionType
  * @param suggestion
  */
-const getMentionValue = (trigger: string, suggestion: Suggestion) => `${trigger}[${suggestion.name}](${suggestion.id})`;
+const getMentionValue = (mentionType: MentionPartType, suggestion: Suggestion) => {
+  let value = `${mentionType.trigger}[${suggestion.name}](${suggestion.id})`;
+
+  if (mentionType.getMentionValue) {
+      value = mentionType.getMentionValue(mentionType.trigger, suggestion.id, suggestion.name);
+  }
+
+  return value;
+};
 
 const getMentionDataFromRegExMatchResult = ([, original, trigger, name, id]: RegexMatchResult): MentionData => ({
   original,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -41,7 +41,7 @@ test('generates plain text part', () => {
 });
 
 test('generates regex result part', () => {
-  const mentionValue = getMentionValue(mentionPartType.trigger, users[1]);
+  const mentionValue = getMentionValue(mentionPartType, users[1]);
   expect(mentionValue).toEqual(`@[Mary](2b)`);
 
   const mentionData = {original: mentionValue, trigger: mentionPartType.trigger, ...users[1]};


### PR DESCRIPTION
In order to be able to achieve custom mention values that does not follow `${trigger}[name](id)`, an optional `getMentionValue` was added to the `MentionPartType` type.

By modifying the `getMentionValue()` function from `utils.ts` we are now able to allow the consumer of the library to specify whatever pattern they want for the mention transformation. 

The consumer also has to specify `pattern` and `parsePattern` so the library can also parse the text in the input properly as the user types. Maybe there is a better way of combining all of those. I am open to suggestions.

Example of code that allows the user to specify a different pattern (i.e. `\uFFFF@[Jack](123)`):
```javascript
export const MyMentionTextInput: React.FC = () => {

  const getMyMentionValue = (
      trigger: string,
      id: string,
      name: string
    ): string => {
      return `\uFFFF${trigger}[${name}](${id})`;
   };

  const myMentionRegex = /\uFFFF((.)\[([^[]*)]\(([^(^)]*)\))/gi;

  return (
    <MentionText
      partTypes={[
        {
          trigger: '@',
          pattern: myMentionRegex,
          getMentionValue: getMyMentionValue,
          parsePattern: ([, , trigger, name, id]) => {
            return {
              original: getMyMentionValue(trigger, id, name),
              trigger,
              name,
              id
            };
          },
          renderSuggestions
        }
      ]}
    />
  );
};
```

You can easily combine this with `react-native-parsed-text` and use `myMentionRegex` to also convert the text into a human-readable format as you wish.