### PR TITLE
Set focus back to input `onSuggestionPress`

### DIFF
--- a/src/components/mention-input.tsx
+++ b/src/components/mention-input.tsx
@@ -89,6 +89,8 @@ const MentionInput: FC<MentionInputProps> = (
 
     onChange(newValue);
 
+    textInput.current?.focus();
+
     /**
      * Move cursor to the end of just added mention starting from trigger string and including:
      * - Length of trigger string


### PR DESCRIPTION
I may not understand the notes well enough regarding the cursor logic but setting focus back works well for our use case. Supporting the +1 would require further work.