### PR TITLE
[new feature] make textStyle accept a function of part data in trigger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,23 +293,23 @@ const patternsConfig: PatternsConfig = {
 
 ### Type `TriggerConfig`
 
-| **Property name**           | **Description**                                                                                 | **Type**                                                  | **Required**                | **Default** |
-|-----------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------|-----------------------------|-------------|
-| `trigger`                   | Character that will trigger current mention type                                                | string                                                    | true                        |             |
-| `pattern`                   | Custom trigger pattern                                                                          | number                                                    | false                       |             |
-| `getTriggerData`            | Callback for getting [TriggerData](#type-triggerdata), is required when we have custom pattern  | (match: string) => [TriggerData](#type-triggerdata)       | true, when `pattern` exists |             |
-| `getTriggerValue`           | Callback for getting trigger value, is required when we have custom pattern                     | (triggerData: [TriggerData](#type-triggerdata)) => string | true, when `pattern` exists |             |
-| `allowedSpacesCount`        | How much spaces are allowed for mention keyword                                                 | number                                                    | false                       |             |
-| `isInsertSpaceAfterMention` | Should we add a space after selected mentions if the mention is at the end of row               | boolean                                                   | false                       | false       |
-| `textStyle`                 | Text style for mentions in `TextInput`                                                          | StyleProp\<TextStyle>                                     | false                       |             |
-| `getPlainString`            | Function for generating custom mention text in text input                                       | (mention: [TriggerData](#type-triggerdata)) => string     | false                       |             |
+| **Property name**           | **Description**                                                                                 | **Type**                                                                        | **Required**                | **Default** |
+|-----------------------------|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|-----------------------------|-------------|
+| `trigger`                   | Character that will trigger current mention type                                                | string                                                                          | true                        |             |
+| `pattern`                   | Custom trigger pattern                                                                          | number                                                                          | false                       |             |
+| `getTriggerData`            | Callback for getting [TriggerData](#type-triggerdata), is required when we have custom pattern  | (match: string) => [TriggerData](#type-triggerdata)                             | true, when `pattern` exists |             |
+| `getTriggerValue`           | Callback for getting trigger value, is required when we have custom pattern                     | (triggerData: [TriggerData](#type-triggerdata)) => string                       | true, when `pattern` exists |             |
+| `allowedSpacesCount`        | How much spaces are allowed for mention keyword                                                 | number                                                                          | false                       |             |
+| `isInsertSpaceAfterMention` | Should we add a space after selected mentions if the mention is at the end of row               | boolean                                                                         | false                       | false       |
+| `textStyle`                 | Text style for mentions in `TextInput`                                                          | StyleProp\<TextStyle> \| (mention: [TriggerData](#type-triggerdata)) => string  | false                       |             |
+| `getPlainString`            | Function for generating custom mention text in text input                                       | (mention: [TriggerData](#type-triggerdata)) => string                           | false                       |             |
 
 ### Type `PatternConfig`
 
-| **Property name** | **Description**                                          | **Type**              | **Required** | **Default** |
-|-------------------|----------------------------------------------------------|-----------------------|--------------|-------------|
-| `pattern`         | RegExp for parsing a pattern, should include global flag | RegExp                | true         |             |
-| `textStyle`       | Text style for pattern in `TextInput`                    | StyleProp\<TextStyle> | false        |             |
+| **Property name** | **Description**                                          | **Type**                                                                       | **Required** | **Default** |
+|-------------------|----------------------------------------------------------|--------------------------------------------------------------------------------|--------------|-------------|
+| `pattern`         | RegExp for parsing a pattern, should include global flag | RegExp                                                                         | true         |             |
+| `textStyle`       | Text style for pattern in `TextInput`                    | StyleProp\<TextStyle> \| (mention: [TriggerData](#type-triggerdata)) => string | false        |             |
 
 ### Type `SuggestionsProvidedProps`
 

--- a/src/hooks/use-mentions.ts
+++ b/src/hooks/use-mentions.ts
@@ -86,18 +86,20 @@ const useMentions = <TriggerName extends string>({
     children: React.createElement(
       Text,
       null,
-      mentionState.parts.map(({ text, config, data }, index) =>
-        config
-          ? React.createElement(
-              Text,
-              {
-                key: `${index}-${data?.trigger ?? 'pattern'}`,
-                style: config.textStyle ?? defaultTriggerTextStyle,
-              },
-              text,
-            )
-          : React.createElement(Text, { key: index }, text),
-      ),
+      mentionState.parts.map(({ text, config, data }, index) => {
+        if (!config) {
+          return React.createElement(Text, { key: index }, text)
+        }
+        const style = typeof config.textStyle === 'function' ? config.textStyle(data) : config.textStyle
+        return React.createElement(
+          Text,
+          {
+            key: `${index}-${data?.trigger ?? 'pattern'}`,
+            style: style ?? defaultTriggerTextStyle,
+          },
+          text,
+        )
+      }),
     ),
   };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -66,7 +66,7 @@ type TriggerConfigBase = {
   isInsertSpaceAfterMention?: boolean;
 
   // Custom mention styles in text input
-  textStyle?: StyleProp<TextStyle>;
+  textStyle?: StyleProp<TextStyle> | ((data?: TriggerData) => StyleProp<TextStyle>);
 
   // Plain string generator for mention
   getPlainString?: (mention: TriggerData) => string;
@@ -88,7 +88,7 @@ type PatternConfig = {
   // RexExp with global flag
   pattern: RegExp;
 
-  textStyle?: StyleProp<TextStyle>;
+  textStyle?: StyleProp<TextStyle> | ((data?: TriggerData) => StyleProp<TextStyle>);
 };
 
 type Config = TriggerConfig | PatternConfig;


### PR DESCRIPTION
This PR adds the possibility of passing a function to `textStyle` when defining `TriggersConfig`.

This function will receive the `TriggerData` for each part and must return a `TextStyle` object.

This adds the possibility of defining triggers with varying styles depending on the trigger data, for example, changing the color in a piece of text. This can be used with a config like this:

```
const triggerConfigs: TriggersConfig<'color'> = {
  color: {
    trigger: '#?',
    pattern: /(\[fg=#[0-9a-fA-F]{6}\]\(.*?\))/gi,
    textStyle: (data) => ({
      color: data?.id,
    }),
    // How to parse regex match and get required for data for internal logic
    getTriggerData: (match) => {
      const [first, last] = match.split('](')
      const color = first.replace('[fg=', '')
      const text = last.replace(')', '');
      return ({
        original: match,
        trigger: '#?',
        name: text,
        id: color,
      });
    },

    // How to generate internal mention value from selected suggestion
    getTriggerValue: (suggestion) => `[fg=${suggestion.id}](${suggestion.name})`,

    // How the highlighted mention will appear in TextInput for user
    getPlainString: (triggerData) => triggerData.name,
  }
}
```

This has been tested on top of the version in the branch `3.0` of the upstream repo.

Documentation in the README has also been updated.

If anyone wants to give it a try, I have published it on NPM: [react-native-more-controlled-mentions](https://www.npmjs.com/package/react-native-more-controlled-mentions)